### PR TITLE
feat: change version to use all release. it's necessary for maple

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.5",
-    install_requires=["tutor>=12.0.0,<13.0.0"],
+    install_requires=["tutor"],
     entry_points={
         "tutor.plugin.v0": [
             "codejail = tutorcodejail.plugin"


### PR DESCRIPTION
Description
----------------
This PR change the version to use all releases lilac, maple, limonero and mango with codejail service.

How to test
---------------
Change was testing in Maple.

1. Clone and use this branch.

`git clone git@github.com:eduNEXT/tutor-contrib-codejail.git`
`git checkout JDB/tutor_version_maple`

2. Install and enable the plugin in stack builder.

`tvm pip install <path-where-the-repo-is>`
`tutor plugins enable codejail`

3. Initialize codejail

`tutor local init --limit codejail`

4. Run the service and go to studio.
5. Import course_codejail_example.tar.gz
[course_codejail_example.tar.gz](https://github.com/eduNEXT/tutor-contrib-codejail/files/8534557/course_codejail_example.tar.gz)

6. Test logcapa problems in the course.