### PR TITLE
feat: add nutmeg release support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[14.0.0] - 2022-05-30
+~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Bump version according tutor practices for Nutmeg release.
+
 [13.0.0] - 2022-05-02
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,8 @@ Compatibility
 +-------------------+----------------+
 |       Maple       |    >= 13.x     |
 +-------------------+----------------+
+|       Nutmeg      |    >= 14.x     |
++-------------------+----------------+
 
 **NOTE**: For the Open edx version of the Lilac release, the changes required for the Codejail service to interact with ``edx-platform`` are
 not included in ``open-release/lilac.master``. In order to use the service with the changes, please review `this PR`_.

--- a/tutorcodejail/__about__.py
+++ b/tutorcodejail/__about__.py
@@ -1,2 +1,2 @@
 """Helps you keep your cool when creating dozens of open edX and eduNEXT environments."""
-__version__ = "13.0.0"
+__version__ = "14.0.0"

--- a/tutorcodejail/plugin.py
+++ b/tutorcodejail/plugin.py
@@ -17,7 +17,7 @@ config = {
         "VERSION": __version__,
         "HOST": "codejailservice",
         "DOCKER_IMAGE": f"docker.io/ednxops/codejailservice:{__version__}",
-        "SANDBOX_PYTHON_VERSION": "3.5.10",
+        "SANDBOX_PYTHON_VERSION": "3.8.6",
     },
     "set": {},
 }

--- a/tutorcodejail/templates/codejail/apps/profiles/docker-edx-sandbox
+++ b/tutorcodejail/templates/codejail/apps/profiles/docker-edx-sandbox
@@ -39,12 +39,12 @@ profile docker-edx-sandbox flags=(attach_disconnected,mediate_deleted) {
     #
     # Python abstractions adapted from https://gitlab.com/apparmor/apparmor/-/raw/master/profiles/apparmor.d/abstractions/python
     #
-    /opt/pyenv/versions/{2.[4-7].*,3.[0-9].*}/lib/python{2.[4-7],3.[0-9]}/**.{pyc,so} mr,
-    /opt/pyenv/versions/{2.[4-7].*,3.[0-9].*}/lib/python{2.[4-7],3.[0-9]}/**.{egg,py,pth} r,
-    /opt/pyenv/versions/{2.[4-7].*,3.[0-9].*}/lib/python{2.[4-7],3.[0-9]}/{site,dist}-packages/ r,
+    /opt/pyenv/versions/3.[0-9].*/lib/python3.[0-9]/**.{pyc,so} mr,
+    /opt/pyenv/versions/3.[0-9].*/lib/python3.[0-9]/**.{egg,py,pth} r,
+    /opt/pyenv/versions/3.[0-9].*/lib/python3.[0-9]/site-packages/ r,
     /opt/pyenv/versions/3.[0-9].*/lib/python3.[0-9]/lib-dynload/*.so mr,
 
-    /opt/pyenv/versions/{2.[4-7].*,3.[0-9].*}/include/python{2.[4-7],3.[0-9]}*/pyconfig.h r,
+    /opt/pyenv/versions/3.[0-9].*/include/python3.[0-9]*/pyconfig.h r,
 
 
     #
@@ -52,10 +52,10 @@ profile docker-edx-sandbox flags=(attach_disconnected,mediate_deleted) {
     # python installation
     #
     /sandbox/venv/** mr,
-    /opt/pyenv/versions/3.5.10/** mr,
+    /opt/pyenv/versions/{{ CODEJAIL_SANDBOX_PYTHON_VERSION }}_sandbox/** mr,
     /tmp/codejail-*/ rix,
     /tmp/codejail-*/** wrix,
-    
+
     #
     # Whitelist particular shared objects from the system
     # python installation

--- a/tutorcodejail/templates/codejail/build/codejail/Dockerfile
+++ b/tutorcodejail/templates/codejail/build/codejail/Dockerfile
@@ -20,10 +20,11 @@ ARG CODEJAILSERVICE_PYTHON_VERSION=3.8.6
 RUN $PYENV_ROOT/bin/pyenv install $CODEJAILSERVICE_PYTHON_VERSION
 
 ARG SANDBOX_PYTHON_VERSION={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}
-RUN $PYENV_ROOT/bin/pyenv install $SANDBOX_PYTHON_VERSION
+RUN git clone https://github.com/s1341/pyenv-alias.git $PYENV_ROOT/plugins/pyenv-alias
+RUN VERSION_ALIAS={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}_sandbox $PYENV_ROOT/bin/pyenv install $SANDBOX_PYTHON_VERSION
 
 RUN $PYENV_ROOT/versions/$CODEJAILSERVICE_PYTHON_VERSION/bin/python -m venv /openedx/venv
-RUN $PYENV_ROOT/versions/$SANDBOX_PYTHON_VERSION/bin/python -m venv --copies /sandbox/venv
+RUN $PYENV_ROOT/versions/"$SANDBOX_PYTHON_VERSION"_sandbox/bin/python -m venv --copies /sandbox/venv
 
 ###### Codejail service code
 FROM minimal as code
@@ -39,7 +40,7 @@ ENV VIRTUAL_ENV /openedx/venv/
 COPY --from=code /openedx/codejailservice /openedx/codejailservice
 WORKDIR /openedx/codejailservice
 RUN pip3 install -r requirements/base.txt
-RUN pip3 install uwsgi==2.0.19.1
+RUN pip3 install uwsgi==2.0.20
 
 ###### Install python requirements in virtualenv
 FROM python as sandbox-python-requirements
@@ -51,9 +52,8 @@ WORKDIR /var/tmp
 RUN mkdir -p common/lib/
 
 COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/common/lib/sandbox-packages common/lib/sandbox-packages
-COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/common/lib/symmath common/lib/symmath
-COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/py35.txt py35.txt
-RUN pip3 install -r py35.txt
+COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/py38.txt py38.txt
+RUN pip3 install -r py38.txt
 
 ##### Prod image
 FROM minimal as production


### PR DESCRIPTION
### Description
This PR adds nutmeg support:
- Update references from Maple to Nutmeg release
- Update AppArmor profile so it uses python > 3 (see [ref](https://github.com/eduNEXT/tutor-contrib-codejail/issues/19))

### How to test
Steps to reproduce the behavior:
1. Install tutor, tutor-contrib-codejail, [codejailservice](https://github.com/eduNEXT/codejailservice) from source
2. Move to nutmeg branches: nutmeg -for tutor-, 14.0.0 -for codejailservice-, MJG/nutmeg -for tutor-contrib-codejail-
3. Install plugin
4. Build images: tutor config save && tutor images build all
5. Init services: tutor dev init
6. Follow test instructions [here](https://github.com/eduNEXT/tutor-contrib-codejail#how-to-know-if-codejail-is-working). The error will appear in the course component.