### PR TITLE
Add kubernetes support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Added
+-----
+* Include k8s templates.
+* Add a setting to run the service without codejail.
+* Add a setting to skip the initialization job.
+* Add a section in the readme with the available configuration values and their defaults.
+
+
 [14.0.0] - 2022-05-30
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,9 @@ Configuration
 
 - ``CODEJAIL_APPARMOR_DOCKER_IMAGE``: (default: ``docker.io/ednxops/codejail_apparmor_loader:latest``)
 - ``CODEJAIL_DOCKER_IMAGE``: (default: ``docker.io/ednxops/codejailservice:14.0.0``)
+- ``CODEJAIL_ENFORCE_APPARMOR`` (default: ``True``)
+- ``CODEJAIL_ENABLE_K8S_DAEMONSET`` (default: ``False``)
+- ``CODEJAIL_SKIP_INIT`` (default: ``False``)
 - ``CODEJAIL_SANDBOX_PYTHON_VERSION`` (default: ``3.8.6``)
 
 Compatibility
@@ -58,6 +61,32 @@ Compatibility
 not included in ``open-release/lilac.master``. In order to use the service with the changes, please review `this PR`_.
 
 .. _this PR: https://github.com/openedx/edx-platform/pull/27795
+
+Kubernetes Support
+------------------
+
+The CodeJail service provides a sandbox to run arbitrary code. Security enforcement
+in the sandbox is done through AppArmor, this means that AppArmor must be installed
+in the host machine and the `provided profile`_ must be loaded.
+
+.. _provided profile: tutorcodejail/templates/codejail/apps/profiles/docker-edx-sandbox
+
+The plugin provides an init task that runs a privileged container capable of loading
+the needed AppArmor profile unto your machine. This is only compatible with a docker
+installation. In Kubernetes you must guarantee that each node of your cluster has
+AppArmor installed and the profile loaded, for that reason the one time initialization
+task that is used in the init is skipped when running on kubernetes.
+
+The plugins offers the possibility to load the AppArmor profile using a DaemonSet,
+assuming the nodes are already running AppArmor. To do so you must set
+``CODEJAIL_ENABLE_K8S_DAEMONSET`` to ``True``.
+
+If, at your own discretion, want to run the service without enforcing the AppArmor
+profile you can set ``CODEJAIL_ENFORCE_APPARMOR`` to ``False``.
+
+More info about this discussion can be found on `this issue`_.
+
+.. _this issue: https://github.com/eduNEXT/tutor-contrib-codejail/issues/24
 
 Functionality test
 ------------------

--- a/tutorcodejail/patches/k8s-deployments
+++ b/tutorcodejail/patches/k8s-deployments
@@ -1,0 +1,86 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: codejailservice
+  labels:
+    app.kubernetes.io/name: codejailservice
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: codejailservice
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: codejailservice
+      annotations:
+        {% if CODEJAIL_ENFORCE_APPARMOR %}
+        container.apparmor.security.beta.kubernetes.io/codejailservice: "localhost/docker-edx-sandbox-{{ CODEJAIL_SANDBOX_PYTHON_VERSION }}"
+        {% endif %}
+    spec:
+      containers:
+        - name: codejailservice
+          image: {{ CODEJAIL_DOCKER_IMAGE }}
+          ports:
+            - containerPort: 8550
+          volumeMounts:
+            - mountPath: /openedx/codejailservice/codejailservice/tutor.py
+              name: settings-codejail
+              subPath: tutor.py
+      volumes:
+        - name: settings-codejail
+          configMap:
+            name: settings-codejail
+{% if CODEJAIL_ENABLE_K8S_DAEMONSET %}
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: codejail-aa-loader
+  labels:
+    app.kubernetes.io/name: codejail-aa-loader
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: codejail-aa-loader
+  template:
+    metadata:
+      name: codejail-aa-loader
+      labels:
+        app.kubernetes.io/name: codejail-aa-loader
+    spec:
+      containers:
+      - name: apparmor-loader
+        image: google/apparmor-loader:latest
+        args:
+          # Tell the loader to pull the /profiles directory every 30 seconds.
+          - -poll
+          - 30s
+          - /profiles
+        securityContext:
+          # The loader requires root permissions to actually load the profiles.
+          privileged: true
+        volumeMounts:
+        - name: sys
+          mountPath: /sys
+          readOnly: true
+        - name: apparmor-includes
+          mountPath: /etc/apparmor.d
+          readOnly: true
+        - name: profiles
+          mountPath: /profiles
+          readOnly: true
+      volumes:
+      # The /sys directory must be mounted to interact with the AppArmor module.
+      - name: sys
+        hostPath:
+          path: /sys
+      # The /etc/apparmor.d directory is required for most apparmor include templates.
+      - name: apparmor-includes
+        hostPath:
+          path: /etc/apparmor.d
+      # Map in the profile data.
+      - name: profiles
+        configMap:
+          name: codejail-profile
+{% endif %}

--- a/tutorcodejail/patches/k8s-jobs
+++ b/tutorcodejail/patches/k8s-jobs
@@ -1,0 +1,21 @@
+---
+# Dummy job that doesn't actually load the profile.
+# To enforce apparmor we need to load the profile
+# on each node, for that reason we use a DaemonSet
+# defined in the k8s-deployments patch.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: codejail-apparmor-job
+  labels:
+    app.kubernetes.io/component: job
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: codejail-apparmor-loader
+        image: busybox:1.28
+        env:
+          - name: SKIP_INIT
+            value: "True"

--- a/tutorcodejail/patches/k8s-services
+++ b/tutorcodejail/patches/k8s-services
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: codejailservice
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8550
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: codejailservice

--- a/tutorcodejail/patches/kustomization-configmapgenerator
+++ b/tutorcodejail/patches/kustomization-configmapgenerator
@@ -1,0 +1,6 @@
+- name: codejail-profile
+  files:
+  - plugins/codejail/apps/profiles/docker-edx-sandbox
+- name: settings-codejail
+  files:
+  - plugins/codejail/apps/config/tutor.py

--- a/tutorcodejail/patches/local-docker-compose-jobs-services
+++ b/tutorcodejail/patches/local-docker-compose-jobs-services
@@ -1,6 +1,8 @@
-codejail_apparmor-job:
+codejail-apparmor-job:
   image: {{ CODEJAIL_APPARMOR_DOCKER_IMAGE }}
   privileged: true
+  environment:
+    SKIP_INIT: "{{ CODEJAIL_SKIP_INIT }}"
   volumes:
     - ../plugins/codejail/apps/profiles/docker-edx-sandbox:/profiles/docker-edx-sandbox:ro
     - /sys:/sys

--- a/tutorcodejail/patches/local-docker-compose-services
+++ b/tutorcodejail/patches/local-docker-compose-services
@@ -3,8 +3,10 @@ codejailservice:
   image: {{ CODEJAIL_DOCKER_IMAGE }}
   environment:
     FLASK_APP_SETTINGS: codejailservice.config.ProductionConfig
+  {% if CODEJAIL_ENFORCE_APPARMOR %}
   security_opt:
-    - apparmor:docker-edx-sandbox
+    - apparmor:docker-edx-sandbox-{{ CODEJAIL_SANDBOX_PYTHON_VERSION }}
+  {% endif %}
   volumes:
     - ../plugins/codejail/apps/config/tutor.py:/openedx/codejailservice/codejailservice/tutor.py:ro
     - ../../data/codejail:/openedx/data

--- a/tutorcodejail/plugin.py
+++ b/tutorcodejail/plugin.py
@@ -16,16 +16,19 @@ config = {
         "VERSION": __version__,
         "APPARMOR_DOCKER_IMAGE": "docker.io/ednxops/codejail_apparmor_loader:latest",
         "DOCKER_IMAGE": f"docker.io/ednxops/codejailservice:{__version__}",
+        "ENABLE_K8S_DAEMONSET": False,
+        "ENFORCE_APPARMOR": True,
         "HOST": "codejailservice",
         "SANDBOX_PYTHON_VERSION": "3.8.6",
+        "SKIP_INIT": False,
     },
     "overrides": {},
 }
 
 
 hooks.Filters.COMMANDS_INIT.add_item((
-    "codejail_apparmor",
-    ("codejail", "tasks", "codejail_apparmor", "init"),
+    "codejail-apparmor",
+    ("codejail", "tasks", "codejail-apparmor", "init"),
 ))
 
 

--- a/tutorcodejail/templates/codejail/apps/profiles/docker-edx-sandbox
+++ b/tutorcodejail/templates/codejail/apps/profiles/docker-edx-sandbox
@@ -1,6 +1,6 @@
 #include <tunables/global>
 
-profile docker-edx-sandbox flags=(attach_disconnected,mediate_deleted) {
+profile docker-edx-sandbox-{{ CODEJAIL_SANDBOX_PYTHON_VERSION }} flags=(attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   network,
@@ -9,7 +9,7 @@ profile docker-edx-sandbox flags=(attach_disconnected,mediate_deleted) {
   umount,
   signal (receive) peer=unconfined,
   signal (receive) peer=cri-containerd.apparmor.d,
-  signal (send,receive) peer=docker-edx-sandbox,
+  signal (send,receive) peer=docker-edx-sandbox-{{ CODEJAIL_SANDBOX_PYTHON_VERSION }},
 
   deny @{PROC}/* w,   # deny write for all files directly in /proc (not in a subdir)
   # deny write to files not in /proc/<number>/** or /proc/sys/**
@@ -30,7 +30,7 @@ profile docker-edx-sandbox flags=(attach_disconnected,mediate_deleted) {
   deny /sys/firmware/** rwklx,
   deny /sys/kernel/security/** rwklx,
 
-  ptrace (trace,read) peer=docker-edx-sandbox,
+  ptrace (trace,read) peer=docker-edx-sandbox-{{ CODEJAIL_SANDBOX_PYTHON_VERSION }},
 
   /sandbox/venv/bin/python Cx -> child,
   profile child flags=(attach_disconnected,mediate_deleted){

--- a/tutorcodejail/templates/codejail/tasks/codejail-apparmor/init
+++ b/tutorcodejail/templates/codejail/tasks/codejail-apparmor/init
@@ -1,0 +1,5 @@
+if [  "$SKIP_INIT" == "True" ]; then
+    echo "Skipped AppArmor initialization"
+else
+    /usr/bin/loader -logtostderr -v=2 /profiles
+fi

--- a/tutorcodejail/templates/codejail/tasks/codejail_apparmor/init
+++ b/tutorcodejail/templates/codejail/tasks/codejail_apparmor/init
@@ -1,1 +1,0 @@
-/usr/bin/loader -logtostderr -v=2 /profiles


### PR DESCRIPTION
## Description

Add the patches needed to deploy on Kubernetes.

To enforce the AppArmor profile on Kubernetes we must load the profile onto the nodes. On a local installation we use the init task to load the profile on the host. The strategy in Kubernetes is to use a [DaemonSet](https://kubernetes.io/docs/tutorials/security/apparmor/#setting-up-nodes-with-profiles) and use a dummy job for the init task.

This also includes three additional settings for choosing whether you want to run codejail in secure mode or skip the init job:

- `CODEJAIL_ENFORCE_APPARMOR`
- `CODEJAIL_ENABLE_K8S_DAEMONSET`
- `CODEJAIL_SKIP_INIT`

The directory containing the init task was renamed to 'codejail-apparmor' to make it conformant with [Kubernetes naming](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).