### PR TITLE
feat: allow to use tmp in python executions DS-483

### DIFF
--- a/tutorcodejail/templates/codejail/apps/profiles/docker-edx-sandbox
+++ b/tutorcodejail/templates/codejail/apps/profiles/docker-edx-sandbox
@@ -55,6 +55,7 @@ profile docker-edx-sandbox-{{ CODEJAIL_SANDBOX_PYTHON_VERSION }} flags=(attach_d
     /opt/pyenv/versions/{{ CODEJAIL_SANDBOX_PYTHON_VERSION }}_sandbox/** mr,
     /tmp/codejail-*/ rix,
     /tmp/codejail-*/** wrix,
+    /tmp/* wrix,
 
     #
     # Whitelist particular shared objects from the system


### PR DESCRIPTION
# Description
This PR is related to #35 and #29. This adds /tmp permissions in the sandbox child profile. This allows using /tmp in Python executions in codejail. However, this only corrects the: "No usable directory" error.

# Without this PR
importing matplotlib
![Screenshot from 2023-05-14 18-08-52](https://github.com/eduNEXT/tutor-contrib-codejail/assets/35668326/58a534c4-5685-4380-b9f5-6b6b1eca73b6)
importing pybryt (if I had pybryt installed, review #35)
![Screenshot from 2023-05-14 18-09-55](https://github.com/eduNEXT/tutor-contrib-codejail/assets/35668326/69d752e8-27e3-4d99-89ba-a15e84d6ce4b)

# How to test
- Use the profile in this PR
    - For test purposes, you can:
        - Have a Tutor env stopped with codejail.
        - Edit env/plugins/codejail/apps/profiles/docker-edx-sandbox with the change and change the name of the profile.
        - Change the profile name in the security_opt in env/local/docker-compose.yml
        - Run: `tutor dev do init --limit codejail` (You get a succeed profile loaded message)
        - Start the env
- Create a Python unit component: Problem >  Advanced > Python
- Import matplotlib (You doesn't have the "No usable directory" error)

# Important note
This resolves #35 and help with #29. But not resolving all of #29, we still have problems with the permission when we import matplotlib.

