### PR TITLE
feat: allows you to add extra pip requirements to your codejail sandbox DS-697

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,13 @@ Configuration
 - ``CODEJAIL_ENABLE_K8S_DAEMONSET`` (default: ``False``)
 - ``CODEJAIL_SKIP_INIT`` (default: ``False``)
 - ``CODEJAIL_SANDBOX_PYTHON_VERSION`` (default: ``3.8.6``)
+- ``CODEJAIL_EXTRA_PIP_REQUIREMENTS`` (optional) A list of pip requirements to add to your sandbox.
+    
+    .. code-block:: yaml
+
+        CODEJAIL_EXTRA_PIP_REQUIREMENTS:
+        - pybryt
+
 
 Compatibility
 -------------

--- a/tutorcodejail/templates/codejail/build/codejail/Dockerfile
+++ b/tutorcodejail/templates/codejail/build/codejail/Dockerfile
@@ -54,6 +54,12 @@ RUN mkdir -p common/lib/
 COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/py38.txt py38.txt
 RUN pip3 install -r py38.txt
 
+# Allows you to add extra pip requirements to your codejail sandbox.
+{% if CODEJAIL_EXTRA_PIP_REQUIREMENTS is defined %}
+{% for extra_requirements in CODEJAIL_EXTRA_PIP_REQUIREMENTS %}RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/openedx/.cache/pip,sharing=shared {% endif %}pip install '{{ extra_requirements }}'
+{% endfor %}
+{% endif %}
+
 ##### Prod image
 FROM minimal as production
 


### PR DESCRIPTION
## Description
This PR allows you to add extra pip requirements to your codejail sandbox.

Related: #41 

## How to test

1. Install this version of `tutor-contrib-codejail`.
2. Add in your tutor `config.yml` the following:
```
CODEJAIL_EXTRA_PIP_REQUIREMENTS:
- pybryt
```
(You can use any pip package)
3. Save your configuration in Tutor.
```
tutor config save
```
4. Create a new codejail image.
```
tutor images build codejail
```
5. Run codejail.
```
tutor local do init --limit codejail
```
6. Launch your environment.
```
tutor local launch
```
## Expected Behavior
- You should be able to import the package you installed in a loncapa problem.
(In Studio > Create a course > Create a Subsection > Create a Unit > Add a Problem > Select Advance and Custom Python-Evaluated Input > Edit the problem > Import the package you installed in the loncapa script)
Example:
```
<script type="loncapa/python">
import pybryt

def test_add_to_ten(expect, ans):
    return test_add(10, ans)

</script>
```