### PR TITLE
feat: add support for quince release DS-697

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[17.0.0] - 2023-11-20
+~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* Allows you to add extra pip requirements to your codejail sandbox (#42)
+* Add support form quince release (#43)
+
 [16.0.0] - 2023-08-18
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,8 @@ Finally, the platform can be run as usual:
 Configuration
 -------------
 
+For some of these configurations to work correctly, the codejail image must be built again. Command to build codejail: ``tutor images build codejail``.
+
 - ``CODEJAIL_APPARMOR_DOCKER_IMAGE``: (default: ``docker.io/ednxops/codejail_apparmor_loader:latest``)
 - ``CODEJAIL_DOCKER_IMAGE``: (default: ``docker.io/ednxops/codejailservice:14.0.0``)
 - ``CODEJAIL_ENFORCE_APPARMOR`` (default: ``True``)
@@ -66,6 +68,8 @@ Compatibility
 | Olive            | >= 15.x       |
 +------------------+---------------+
 | Palm             | >= 16.x       |
++------------------+---------------+
+| Quince           | >= 17.x       |
 +------------------+---------------+
 
 **NOTE**: For the Open edx version of the Lilac release, the changes required for the Codejail service to interact with ``edx-platform`` are

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor<17.0.0"],
+    install_requires=["tutor<18.0.0"],
     entry_points={"tutor.plugin.v1": ["codejail = tutorcodejail.plugin"]},
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tutorcodejail/__about__.py
+++ b/tutorcodejail/__about__.py
@@ -1,2 +1,2 @@
 """Helps you keep your cool when creating dozens of open edX and eduNEXT environments."""
-__version__ = "16.0.0"
+__version__ = "17.0.0"


### PR DESCRIPTION
## Description

This PR updated the versions to support Quince Open edX release.

## How to test

### Requirements

#### Have the Quince environment

1. Install the quince branch from the tutor repository.
2. If you use mfes, you must install the quince branch from tutor-mfe.
3. Build all the necessary images.
```
tutor images build permissions
tutor images build mfe
tutor images build openedx
```

### Install codejail

1. Install this branch.
2. Activate the plugin.
```
tutor plugins enable codejail
tutor config save
```
3. Init the service and launch
```
tutor local do init --limit codejail
tutor local launch
```

### Expected Behavior

Be able to use correctly the loncapa/problems.

#### Manually

In Studio > Create a course > Create a Subsection > Create a Unit > Add a Problem > Select Advance and Custom Python-Evaluated Input.

#### Importing a course with loncapa problems

In Studio > Create a course > Tools > Import

Import this course: https://github.com/eduNEXT/tutor-contrib-codejail/blob/main/docs/resources/course_codejail_example.tar.gz