### PR TITLE
Upgrade to Redwood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ __pycache__/
 TODO
 # Distribution / packaging
 .Python
-build/
+/build/
 develop-eggs/
 dist/
 downloads/

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor>=17.0.2, <18"],
+    install_requires=["tutor>=17.0.2, <19"],
     entry_points={"tutor.plugin.v1": ["codejail = tutorcodejail.plugin"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -55,5 +55,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tutorcodejail/__about__.py
+++ b/tutorcodejail/__about__.py
@@ -1,2 +1,2 @@
 """Helps you keep your cool when creating dozens of open edX and eduNEXT environments."""
-__version__ = "17.0.1"
+__version__ = "18.0.0"

--- a/tutorcodejail/plugin.py
+++ b/tutorcodejail/plugin.py
@@ -30,6 +30,7 @@ config = {
         "MIN_REPLICAS": 1,
         "MAX_REPLICAS": 4,
         "AVG_CPU": 65,
+        "SERVICE_VERSION": "main",
     },
     "overrides": {},
 }

--- a/tutorcodejail/plugin.py
+++ b/tutorcodejail/plugin.py
@@ -20,7 +20,7 @@ config = {
         "ENABLE_K8S_DAEMONSET": False,
         "ENFORCE_APPARMOR": True,
         "HOST": "codejailservice",
-        "SANDBOX_PYTHON_VERSION": "3.8.6",
+        "SANDBOX_PYTHON_VERSION": "3.11.9",
         "SKIP_INIT": False,
         "LIMIT_CPU": "1",
         "LIMIT_MEMORY": "1Gi",

--- a/tutorcodejail/templates/codejail/build/codejail/Dockerfile
+++ b/tutorcodejail/templates/codejail/build/codejail/Dockerfile
@@ -14,13 +14,13 @@ RUN apt update && \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git subversion
 ENV PYENV_ROOT /opt/pyenv
-RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.3.5 --depth 1
+RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.4.0 --depth 1
 
-ARG CODEJAILSERVICE_PYTHON_VERSION=3.8.6
+ARG CODEJAILSERVICE_PYTHON_VERSION=3.11.9
 RUN $PYENV_ROOT/bin/pyenv install $CODEJAILSERVICE_PYTHON_VERSION
 
 ARG SANDBOX_PYTHON_VERSION={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}
-RUN git clone https://github.com/s1341/pyenv-alias.git $PYENV_ROOT/plugins/pyenv-alias
+RUN git clone https://github.com/esinker/pyenv-version-alias $PYENV_ROOT/plugins/pyenv-alias
 RUN VERSION_ALIAS={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}_sandbox $PYENV_ROOT/bin/pyenv install $SANDBOX_PYTHON_VERSION
 
 RUN $PYENV_ROOT/versions/$CODEJAILSERVICE_PYTHON_VERSION/bin/python -m venv /openedx/venv
@@ -28,7 +28,7 @@ RUN $PYENV_ROOT/versions/"$SANDBOX_PYTHON_VERSION"_sandbox/bin/python -m venv --
 
 ###### Codejail service code
 FROM minimal as code
-RUN git clone https://github.com/eduNEXT/codejailservice.git --branch {{ CODEJAIL_VERSION }} --depth 1 /openedx/codejailservice
+RUN git clone https://github.com/eduNEXT/codejailservice.git --branch {{ CODEJAIL_SERVICE_VERSION }} --depth 1 /openedx/codejailservice
 WORKDIR /openedx/codejailservice
 
 ###### Install python requirements in virtualenv
@@ -52,6 +52,7 @@ WORKDIR /var/tmp
 RUN mkdir -p common/lib/
 
 COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/py38.txt py38.txt
+COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/releases/quince.txt releases/quince.txt
 RUN pip3 install -r py38.txt
 
 # Allows you to add extra pip requirements to your codejail sandbox.

--- a/tutorcodejail/templates/codejail/build/codejail/Dockerfile
+++ b/tutorcodejail/templates/codejail/build/codejail/Dockerfile
@@ -21,7 +21,7 @@ RUN $PYENV_ROOT/bin/pyenv install $CODEJAILSERVICE_PYTHON_VERSION
 
 ARG SANDBOX_PYTHON_VERSION={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}
 RUN git clone https://github.com/esinker/pyenv-version-alias $PYENV_ROOT/plugins/pyenv-alias
-RUN VERSION_ALIAS={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}_sandbox $PYENV_ROOT/bin/pyenv install $SANDBOX_PYTHON_VERSION
+RUN VERSION_ALIAS={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}_sandbox $PYENV_ROOT/bin/pyenv install -f $SANDBOX_PYTHON_VERSION
 
 RUN $PYENV_ROOT/versions/$CODEJAILSERVICE_PYTHON_VERSION/bin/python -m venv /openedx/venv
 RUN $PYENV_ROOT/versions/"$SANDBOX_PYTHON_VERSION"_sandbox/bin/python -m venv --copies /sandbox/venv
@@ -51,9 +51,8 @@ ENV VIRTUAL_ENV /sandbox/venv/
 WORKDIR /var/tmp
 RUN mkdir -p common/lib/
 
-COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/py38.txt py38.txt
-COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/releases/quince.txt releases/quince.txt
-RUN pip3 install -r py38.txt
+COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/releases/redwood.txt redwood.txt
+RUN pip3 install -r redwood.txt
 
 # Allows you to add extra pip requirements to your codejail sandbox.
 {% if CODEJAIL_EXTRA_PIP_REQUIREMENTS is defined %}


### PR DESCRIPTION
# Description

**WIP**

Initial redwood support

- Add a variable to change the version of https://github.com/eduNEXT/codejailservice
- Update pyenv to v2.4.0
- Use an updated version for the alias pyenv plugin. More info in this issue (https://github.com/pyenv/pyenv/issues/1956#issuecomment-1709468376)
- Use python 3.11 for both the Flask service and the codejail sandbox virtualenv