### PR TITLE
Upgrade to Redwood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ __pycache__/
 TODO
 # Distribution / packaging
 .Python
-build/
+/build/
 develop-eggs/
 dist/
 downloads/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,21 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[18.0.0] - 2024-06-26
+~~~~~~~~~~~~~~~~~~~~~
+* feat: redwood support
+
+  Add two new variables to enable the use of custom versions/forks of
+  `edunext/codejailservice`.
+
+  BREAKING CHANGE: the default Python version of the sandbox environment
+  has been bumped to 3.11. This change alongside the upgrade of the SciPy
+  and NumPy dependencies may cause some instructor code to fail.
+
+[17.0.2] - 2024-05-24
+~~~~~~~~~~~~~~~~~~~~~
+* fix: use tutor config on codejail service and add patches to edit it DS-894 (#55)
+
 [17.0.1] - 2023-11-20
 ~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 Codejail plugin for `Tutor`_
 ============================
 
-Tutor plugin that configures and runs a `Codejail Service`_ using a REST API. `Codejail`_ allows for the 
+Tutor plugin that configures and runs a `Codejail Service`_ using a REST API. `Codejail`_ allows for the
 secure execution of untrusted code within sandboxes, providing a safe environment for running potentially dangerous code.
 
 .. _Tutor: https://docs.tutor.overhang.io
@@ -21,7 +21,7 @@ You can install a specific version by adding the tag, branch, or commit:
 
 .. code-block:: bash
 
-    pip install git+https://github.com/edunext/tutor-contrib-codejail@v17.0.0
+    pip install git+https://github.com/edunext/tutor-contrib-codejail@v18.0.0
 
 Usage
 -----
@@ -58,14 +58,16 @@ To customize the configuration, update the following settings in Tutor:
 - ``CODEJAIL_SKIP_INIT`` (default: ``False``)
 - ``CODEJAIL_SANDBOX_PYTHON_VERSION`` (default: ``3.8.6``)
 - ``CODEJAIL_EXTRA_PIP_REQUIREMENTS`` (optional) A list of pip requirements to add to your sandbox.
-    
+- ``CODEJAIL_SERVICE_VERSION`` (default: ``release/redwood.1``),
+- ``CODEJAIL_SERVICE_REPOSITORY`` (default ``https://github.com/edunext/codejailservice.git```)
+
 .. code-block:: yaml
 
     CODEJAIL_EXTRA_PIP_REQUIREMENTS:
     - pybryt
-    
 
-Custom Image 
+
+Custom Image
 ~~~~~~~~~~~~
 
 In most cases, you can work with the provided docker image for the release. However, you will need to re-build the docker image when:
@@ -81,7 +83,7 @@ Create a new image running:
     # Add the tutor configuration with the custom value
     tutor config save \
     --set 'CODEJAIL_EXTRA_PIP_REQUIREMENTS=["pybryt"]'
-    
+
     # Build the image
     tutor images build codejail
 
@@ -104,6 +106,8 @@ Compatibility
 +------------------+---------------+
 | Quince           | >= 17.x       |
 +------------------+---------------+
+| Redwood          | >= 18.x       |
++------------------+---------------+
 
 **NOTE**: For the Open edX version of the Lilac release, the changes required for the Codejail service to interact with ``edx-platform`` are
 not included in ``open-release/lilac.master``. To use the service with the changes, please review `this PR`_.
@@ -122,8 +126,8 @@ in the host machine and the `provided profile`_ must be loaded.
 The plugin provides an init task running a privileged container capable of loading the AppArmor profile onto your machine.
 This is only compatible with a docker installation.
 
-For Kubernetes environments, ensure each node has AppArmor installed and the profile loaded. Optionally, 
-set ``CODEJAIL_ENABLE_K8S_DAEMONSET`` to True to use a DaemonSet for loading the AppArmor profile, 
+For Kubernetes environments, ensure each node has AppArmor installed and the profile loaded. Optionally,
+set ``CODEJAIL_ENABLE_K8S_DAEMONSET`` to True to use a DaemonSet for loading the AppArmor profile,
 assuming the nodes are already running AppArmor.
 
 If you choose to run the service without enforcing the AppArmor profile, you can set ``CODEJAIL_ENFORCE_APPARMOR`` to ``False``.
@@ -165,7 +169,7 @@ In case you forget to run ``tutor local do init --limit codejail`` for AppArmor 
     :align: center
     :alt: Example when codejail is not working
 
-This indicates that the Codejail service is either not turned on or not working properly. Please ensure to follow 
+This indicates that the Codejail service is either not turned on or not working properly. Please ensure to follow
 the steps outlined in the usage section to prevent this issue.
 
 How to Contribute

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     include_package_data=True,
     python_requires=">=3.8",
-    install_requires=["tutor>=17.0.2, <18"],
+    install_requires=["tutor>=18.0.0, <19"],
     entry_points={"tutor.plugin.v1": ["codejail = tutorcodejail.plugin"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -55,5 +55,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/tutorcodejail/__about__.py
+++ b/tutorcodejail/__about__.py
@@ -1,2 +1,2 @@
 """Helps you keep your cool when creating dozens of open edX and eduNEXT environments."""
-__version__ = "17.0.2"
+__version__ = "18.0.0"

--- a/tutorcodejail/plugin.py
+++ b/tutorcodejail/plugin.py
@@ -20,7 +20,7 @@ config = {
         "ENABLE_K8S_DAEMONSET": False,
         "ENFORCE_APPARMOR": True,
         "HOST": "codejailservice",
-        "SANDBOX_PYTHON_VERSION": "3.8.6",
+        "SANDBOX_PYTHON_VERSION": "3.11.9",
         "SKIP_INIT": False,
         "LIMIT_CPU": "1",
         "LIMIT_MEMORY": "1Gi",
@@ -30,6 +30,8 @@ config = {
         "MIN_REPLICAS": 1,
         "MAX_REPLICAS": 4,
         "AVG_CPU": 65,
+        "SERVICE_VERSION": "release/redwood.1",
+        "SERVICE_REPOSITORY": "https://github.com/edunext/codejailservice.git",
     },
     "overrides": {},
 }

--- a/tutorcodejail/templates/codejail/build/codejail/Dockerfile
+++ b/tutorcodejail/templates/codejail/build/codejail/Dockerfile
@@ -14,21 +14,21 @@ RUN apt update && \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
     xz-utils tk-dev libffi-dev liblzma-dev python3-openssl git subversion
 ENV PYENV_ROOT /opt/pyenv
-RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.3.5 --depth 1
+RUN git clone https://github.com/pyenv/pyenv $PYENV_ROOT --branch v2.4.0 --depth 1
 
-ARG CODEJAILSERVICE_PYTHON_VERSION=3.8.6
+ARG CODEJAILSERVICE_PYTHON_VERSION=3.11.9
 RUN $PYENV_ROOT/bin/pyenv install $CODEJAILSERVICE_PYTHON_VERSION
 
 ARG SANDBOX_PYTHON_VERSION={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}
-RUN git clone https://github.com/s1341/pyenv-alias.git $PYENV_ROOT/plugins/pyenv-alias
-RUN VERSION_ALIAS={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}_sandbox $PYENV_ROOT/bin/pyenv install $SANDBOX_PYTHON_VERSION
+RUN git clone https://github.com/esinker/pyenv-version-alias $PYENV_ROOT/plugins/pyenv-alias
+RUN VERSION_ALIAS={{ CODEJAIL_SANDBOX_PYTHON_VERSION }}_sandbox $PYENV_ROOT/bin/pyenv install -f $SANDBOX_PYTHON_VERSION
 
 RUN $PYENV_ROOT/versions/$CODEJAILSERVICE_PYTHON_VERSION/bin/python -m venv /openedx/venv
 RUN $PYENV_ROOT/versions/"$SANDBOX_PYTHON_VERSION"_sandbox/bin/python -m venv --copies /sandbox/venv
 
 ###### Codejail service code
 FROM minimal as code
-RUN git clone https://github.com/eduNEXT/codejailservice.git --branch {{ CODEJAIL_VERSION }} --depth 1 /openedx/codejailservice
+RUN git clone {{ CODEJAIL_SERVICE_REPOSITORY }} --branch {{ CODEJAIL_SERVICE_VERSION }} --depth 1 /openedx/codejailservice
 WORKDIR /openedx/codejailservice
 
 ###### Install python requirements in virtualenv
@@ -51,8 +51,8 @@ ENV VIRTUAL_ENV /sandbox/venv/
 WORKDIR /var/tmp
 RUN mkdir -p common/lib/
 
-COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/py38.txt py38.txt
-RUN pip3 install -r py38.txt
+COPY --from={{ DOCKER_IMAGE_OPENEDX }} /openedx/edx-platform/requirements/edx-sandbox/releases/redwood.txt redwood.txt
+RUN pip3 install -r redwood.txt
 
 # Allows you to add extra pip requirements to your codejail sandbox.
 {% if CODEJAIL_EXTRA_PIP_REQUIREMENTS is defined %}


### PR DESCRIPTION
# Description

Redwood upgrade

- Add a variable to change the version of https://github.com/eduNEXT/codejailservice
- Update pyenv to v2.4.0
- Use an updated version for the alias pyenv plugin. More info in this issue (https://github.com/pyenv/pyenv/issues/1956#issuecomment-1709468376)
- Use python 3.11 for both the Flask service and the codejail sandbox virtualenv