### PR TITLE
fix: set FLASK_APP_SETTINGS env for k8s-deployment

### DIFF
--- a/tutorcodejail/patches/k8s-deployments
+++ b/tutorcodejail/patches/k8s-deployments
@@ -23,6 +23,9 @@ spec:
           image: {{ CODEJAIL_DOCKER_IMAGE }}
           ports:
             - containerPort: 8550
+          env:
+            - name: FLASK_APP_SETTINGS
+              value: codejailservice.tutor.ProductionConfig
           volumeMounts:
             - mountPath: /openedx/codejailservice/codejailservice/tutor.py
               name: settings-codejail


### PR DESCRIPTION
The `FLASK_APP_SETTINGS` is missing for k8s-deployment causing the usage of the default Production config only.