### PR TITLE
ci: fix pypi publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
+  publish:
 
     runs-on: ubuntu-latest
 
@@ -34,7 +34,7 @@ jobs:
       run: |
         python -m build --sdist --wheel --outdir dist/ .
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.10.3
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
There was an error in the [last publish event](https://github.com/eduNEXT/tutor-contrib-codejail/actions/runs/14313661983/job/40114565961). We are bumping the release action in order to fix it.

A succesful run to the testpypi index can be seen here: https://github.com/eduNEXT/tutor-contrib-codejail/actions/runs/14315207505/job/40119666684. The associated commit is the following: https://github.com/eduNEXT/tutor-contrib-codejail/commit/7a0c72c44cd15e4dae9fa96084ef97a39d745fbb
