### PR TITLE
fix: wait for the apparmor profile before starting

### DIFF
--- a/tutorcodejail/patches/local-docker-compose-services
+++ b/tutorcodejail/patches/local-docker-compose-services
@@ -12,7 +12,8 @@ codejailservice:
     - ../plugins/codejail/apps/codejail-service-v2/tutor.py:/app/codejail_service/settings/tutor.py:ro
   restart: unless-stopped
   depends_on:
-    - codejail-apparmor-loader
+    codejail-apparmor-loader:
+        condition: service_completed_successfully
 {% else %}
 codejailservice:
   image: {{ CODEJAIL_DOCKER_IMAGE }}
@@ -26,7 +27,8 @@ codejailservice:
     - ../plugins/codejail/apps/codejail/tutor.py:/openedx/codejailservice/codejailservice/tutor.py:ro
   restart: unless-stopped
   depends_on:
-    - codejail-apparmor-loader
+    codejail-apparmor-loader:
+        condition: service_completed_successfully
 {% endif %}
 
 codejail-apparmor-loader:


### PR DESCRIPTION
Use [service_completed_successfully](https://docs.docker.com/compose/how-tos/startup-order/) to ensure the codejailservice container starts only after the AppArmor profile is loaded.

At the moment starting the container (`tutor local start -d`) fails with the following error:

```
Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: unable to apply apparmor profile: apparmor failed to apply profile: write fsmount:fscontext:proc/thread-self/attr/apparmor/exec: no such file or directory
```
The workaround is run the command again.
